### PR TITLE
Disallow invalid `NaN` value in JSON

### DIFF
--- a/batch_update_arc69/update_meta_arc69.py
+++ b/batch_update_arc69/update_meta_arc69.py
@@ -28,7 +28,7 @@ def update_meta (n, csv_path, mnemonic1, external_url, description, testnet=True
       "value": items[n]}
     )
     
-    out = json.dumps(l)
+    out = json.dumps(l, allow_nan=False)
     
     if (external_url==""):
         if (description==""):


### PR DESCRIPTION
This PR updates the JSON generation to disallow the `NaN` value, since it makes JSON invalid. Surprisingly, the Python `json` lib defaults to allowing `NaN` 🤦‍♀️